### PR TITLE
Add OWNERS and repository governance files

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+contact_links:
+  - name: Kubernetes slack
+    url: https://slack.k8s.io/
+    about: |
+      Join us on #olm-dev for discussions related to OLM Development or on
+      #kubernetes-operators for discussions related to the Operator pattern of Kubernetes API extension.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 14
+    commit-message:
+      prefix: "chore"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 14
+    commit-message:
+      prefix: "chore"
+    groups:
+      k8s-dependencies:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+# Description
+
+<!--
+Thank you for your contribution!
+
+Please provide a summary of the changes and the motivation behind the change.
+-->
+
+## Reviewer Checklist
+
+- [ ] API Go Documentation
+- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
+- [ ] Comprehensive Commit Messages
+- [ ] Links to related GitHub Issue(s)

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+  - grokspawn
+  - joelanford
+  - kevinrizza
+  - pedjak
+  - perdasilva
+  - tmshort
+
+reviewers:
+  - ankitathomas
+  - dtfranz
+  - fgiudici
+  - grokspawn
+  - joelanford
+  - pedjak
+  - perdasilva
+  - rashmigottipati
+  - tmshort


### PR DESCRIPTION
Part 1/6 in the OLMv0→OLMv1 migration library stack (OPRUN-4717). Adds OWNERS, PR template, issue template, and dependabot config.