### PR TITLE
Add migration/pkg/catalogmigration: CatalogSource → ClusterCatalog (Phase 5)

### DIFF
--- a/migration/pkg/catalogmigration/catalogmigration.go
+++ b/migration/pkg/catalogmigration/catalogmigration.go
@@ -1,0 +1,403 @@
+// Package catalogmigration provides an API for migrating OLMv0 CatalogSources
+// to OLMv1 ClusterCatalogs.
+package catalogmigration
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+)
+
+const (
+	// MigratedFromCatalogSourceAnnotation is set on ClusterCatalog when first created or adopted.
+	MigratedFromCatalogSourceAnnotation = "olm.operatorframework.io/migrated-from-catalogsource"
+)
+
+// CatalogMigratorOptions configures the catalog migration.
+type CatalogMigratorOptions struct {
+	DryRun                      bool
+	DeleteCatalogSource         bool
+	AcknowledgePriorityOverflow bool
+}
+
+// CatalogMigrationResult describes the outcome for a single CatalogSource.
+type CatalogMigrationResult struct {
+	CatalogSourceName      string
+	CatalogSourceNamespace string
+	ClusterCatalogName     string
+	Status                 string // "created", "adopted", "skipped", "error", "dry-run"
+	Reason                 string
+	Notes                  []string // informational notices (e.g. dropped fields with no OLMv1 equivalent)
+}
+
+// CatalogMigrator migrates OLMv0 CatalogSources to OLMv1 ClusterCatalogs.
+type CatalogMigrator struct {
+	Client client.Client
+}
+
+// NewCatalogMigrator creates a new CatalogMigrator.
+func NewCatalogMigrator(c client.Client) *CatalogMigrator {
+	return &CatalogMigrator{Client: c}
+}
+
+// MigrateCatalogs processes all CatalogSources across all namespaces and maps them to ClusterCatalogs.
+// Strategy (per R8):
+//   - Same name + same image across namespaces → consolidate into a single ClusterCatalog
+//   - Same name + different image across namespaces → use <name>-<namespace> for each
+//   - Unique name → use metadata.name directly
+func (cm *CatalogMigrator) MigrateCatalogs(ctx context.Context, opts CatalogMigratorOptions) ([]CatalogMigrationResult, error) {
+	// List all CatalogSources across all namespaces
+	var csList operatorsv1alpha1.CatalogSourceList
+	if err := cm.Client.List(ctx, &csList); err != nil {
+		return nil, fmt.Errorf("failed to list CatalogSources: %w", err)
+	}
+
+	// List all existing ClusterCatalogs
+	var ccList ocv1.ClusterCatalogList
+	if err := cm.Client.List(ctx, &ccList); err != nil {
+		return nil, fmt.Errorf("failed to list ClusterCatalogs: %w", err)
+	}
+
+	// Build map of existing ClusterCatalogs by image ref
+	existingByImage := make(map[string]*ocv1.ClusterCatalog)
+	for i := range ccList.Items {
+		cc := &ccList.Items[i]
+		if cc.Spec.Source.Image != nil && cc.Spec.Source.Image.Ref != "" {
+			existingByImage[cc.Spec.Source.Image.Ref] = cc
+		}
+	}
+
+	// List all Subscriptions to detect which CatalogSources are still referenced
+	var subList operatorsv1alpha1.SubscriptionList
+	if err := cm.Client.List(ctx, &subList); err != nil {
+		return nil, fmt.Errorf("failed to list Subscriptions: %w", err)
+	}
+
+	// Build set of referenced CatalogSources
+	referencedCS := make(map[string]bool)
+	for _, sub := range subList.Items {
+		key := fmt.Sprintf("%s/%s", sub.Spec.CatalogSourceNamespace, sub.Spec.CatalogSource)
+		referencedCS[key] = true
+	}
+
+	// Determine naming strategy: group by name, check for image conflicts
+	type csEntry struct {
+		cs    operatorsv1alpha1.CatalogSource
+		image string
+	}
+	byName := make(map[string][]csEntry)
+	for _, cs := range csList.Items {
+		if cs.Spec.SourceType != operatorsv1alpha1.SourceTypeGrpc || cs.Spec.Image == "" {
+			continue // non-image sources handled separately below
+		}
+		byName[cs.Name] = append(byName[cs.Name], csEntry{cs: cs, image: cs.Spec.Image})
+	}
+
+	// For each name, determine if all entries share the same image
+	nameStrategy := make(map[string]string) // cs name → "shared" or "namespace"
+	for name, entries := range byName {
+		allSame := true
+		firstImage := entries[0].image
+		for _, e := range entries[1:] {
+			if e.image != firstImage {
+				allSame = false
+				break
+			}
+		}
+		if allSame {
+			nameStrategy[name] = "shared"
+		} else {
+			nameStrategy[name] = "namespace"
+		}
+	}
+
+	var results []CatalogMigrationResult
+
+	// Process non-image CatalogSources
+	for _, cs := range csList.Items {
+		if cs.Spec.SourceType == operatorsv1alpha1.SourceTypeGrpc && cs.Spec.Image != "" {
+			continue // handled in the main loop below
+		}
+		reason := ""
+		switch {
+		case cs.Spec.SourceType == operatorsv1alpha1.SourceTypeConfigmap:
+			reason = "configmap-type CatalogSource has no OLMv1 equivalent"
+		case cs.Spec.SourceType == operatorsv1alpha1.SourceTypeInternal:
+			reason = "internal-type CatalogSource has no OLMv1 equivalent"
+		case cs.Spec.SourceType == operatorsv1alpha1.SourceTypeGrpc && cs.Spec.Image == "":
+			reason = "grpc address-only CatalogSource (no spec.image) has no OLMv1 equivalent"
+		default:
+			reason = fmt.Sprintf("unsupported sourceType %q", cs.Spec.SourceType)
+		}
+		results = append(results, CatalogMigrationResult{
+			CatalogSourceName:      cs.Name,
+			CatalogSourceNamespace: cs.Namespace,
+			Status:                 "skipped",
+			Reason:                 reason,
+		})
+	}
+
+	// Track which ClusterCatalog names we've already created this run (for consolidation)
+	createdThisRun := make(map[string]bool)
+
+	// Process image-type CatalogSources
+	for _, cs := range csList.Items {
+		if cs.Spec.SourceType != operatorsv1alpha1.SourceTypeGrpc || cs.Spec.Image == "" {
+			continue
+		}
+
+		// Determine ClusterCatalog name
+		var ccName string
+		switch nameStrategy[cs.Name] {
+		case "shared":
+			ccName = cs.Name
+		default:
+			ccName = fmt.Sprintf("%s-%s", cs.Name, cs.Namespace)
+		}
+
+		// Validate and convert priority
+		priority, priorityErr := validatePriority(cs.Spec.Priority, opts.AcknowledgePriorityOverflow)
+		if priorityErr != nil {
+			results = append(results, CatalogMigrationResult{
+				CatalogSourceName:      cs.Name,
+				CatalogSourceNamespace: cs.Namespace,
+				ClusterCatalogName:     ccName,
+				Status:                 "skipped",
+				Reason:                 priorityErr.Error(),
+			})
+			continue
+		}
+
+		// Convert poll interval
+		pollMinutes := convertPollInterval(cs)
+
+		// Collect informational notes for fields that have no OLMv1 equivalent (R8).
+		var notes []string
+		if len(cs.Spec.Secrets) > 0 {
+			notes = append(notes, fmt.Sprintf("spec.secrets (%d secret(s)) has no OLMv1 equivalent; OLMv1 uses the cluster global pull secret", len(cs.Spec.Secrets)))
+		}
+		if cs.Spec.GrpcPodConfig != nil {
+			notes = append(notes, "spec.grpcPodConfig has no OLMv1 equivalent; catalogd manages the serving pod configuration")
+		}
+
+		csRef := fmt.Sprintf("%s/%s", cs.Namespace, cs.Name)
+
+		// Check if already created this run (consolidation case)
+		if createdThisRun[ccName] {
+			results = append(results, CatalogMigrationResult{
+				CatalogSourceName:      cs.Name,
+				CatalogSourceNamespace: cs.Namespace,
+				ClusterCatalogName:     ccName,
+				Status:                 "adopted",
+				Reason:                 fmt.Sprintf("consolidated into shared ClusterCatalog %s", ccName),
+				Notes:                  notes,
+			})
+			continue
+		}
+
+		// Check if an existing ClusterCatalog matches by image
+		if existing, found := existingByImage[cs.Spec.Image]; found {
+			// Adopt: set annotation if not already present
+			if opts.DryRun {
+				results = append(results, CatalogMigrationResult{
+					CatalogSourceName:      cs.Name,
+					CatalogSourceNamespace: cs.Namespace,
+					ClusterCatalogName:     existing.Name,
+					Status:                 "dry-run",
+					Reason:                 fmt.Sprintf("would adopt existing ClusterCatalog %s", existing.Name),
+					Notes:                  notes,
+				})
+				continue
+			}
+
+			if err := cm.annotateIfNotPresent(ctx, existing, csRef); err != nil {
+				results = append(results, CatalogMigrationResult{
+					CatalogSourceName:      cs.Name,
+					CatalogSourceNamespace: cs.Namespace,
+					ClusterCatalogName:     existing.Name,
+					Status:                 "error",
+					Reason:                 fmt.Sprintf("failed to annotate existing ClusterCatalog: %v", err),
+					Notes:                  notes,
+				})
+				continue
+			}
+
+			createdThisRun[existing.Name] = true
+			results = append(results, CatalogMigrationResult{
+				CatalogSourceName:      cs.Name,
+				CatalogSourceNamespace: cs.Namespace,
+				ClusterCatalogName:     existing.Name,
+				Status:                 "adopted",
+				Reason:                 "existing ClusterCatalog with matching image adopted",
+				Notes:                  notes,
+			})
+
+			// Handle --delete-catalogsource
+			if opts.DeleteCatalogSource && !referencedCS[csRef] {
+				_ = cm.Client.Delete(ctx, &cs)
+			}
+			continue
+		}
+
+		// Create new ClusterCatalog
+		if opts.DryRun {
+			results = append(results, CatalogMigrationResult{
+				CatalogSourceName:      cs.Name,
+				CatalogSourceNamespace: cs.Namespace,
+				ClusterCatalogName:     ccName,
+				Status:                 "dry-run",
+				Reason:                 fmt.Sprintf("would create ClusterCatalog %s from image %s", ccName, cs.Spec.Image),
+				Notes:                  notes,
+			})
+			continue
+		}
+
+		imageSource := &ocv1.ImageSource{Ref: cs.Spec.Image}
+		if pollMinutes > 0 {
+			imageSource.PollIntervalMinutes = &pollMinutes
+		}
+
+		cc := &ocv1.ClusterCatalog{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ccName,
+				Annotations: map[string]string{
+					MigratedFromCatalogSourceAnnotation: csRef,
+				},
+			},
+			Spec: ocv1.ClusterCatalogSpec{
+				Source: ocv1.CatalogSource{
+					Type:  ocv1.SourceTypeImage,
+					Image: imageSource,
+				},
+				Priority:         priority,
+				AvailabilityMode: ocv1.AvailabilityModeAvailable,
+			},
+		}
+
+		if err := cm.Client.Create(ctx, cc); err != nil {
+			results = append(results, CatalogMigrationResult{
+				CatalogSourceName:      cs.Name,
+				CatalogSourceNamespace: cs.Namespace,
+				ClusterCatalogName:     ccName,
+				Status:                 "error",
+				Reason:                 fmt.Sprintf("failed to create ClusterCatalog: %v", err),
+				Notes:                  notes,
+			})
+			continue
+		}
+
+		// Wait for serving
+		if err := cm.waitForServing(ctx, ccName); err != nil {
+			results = append(results, CatalogMigrationResult{
+				CatalogSourceName:      cs.Name,
+				CatalogSourceNamespace: cs.Namespace,
+				ClusterCatalogName:     ccName,
+				Status:                 "error",
+				Reason:                 fmt.Sprintf("ClusterCatalog not serving: %v", err),
+				Notes:                  notes,
+			})
+			continue
+		}
+
+		createdThisRun[ccName] = true
+		existingByImage[cs.Spec.Image] = cc
+
+		results = append(results, CatalogMigrationResult{
+			CatalogSourceName:      cs.Name,
+			CatalogSourceNamespace: cs.Namespace,
+			ClusterCatalogName:     ccName,
+			Status:                 "created",
+			Reason:                 fmt.Sprintf("created from image %s", cs.Spec.Image),
+			Notes:                  notes,
+		})
+
+		// Handle --delete-catalogsource
+		if opts.DeleteCatalogSource && !referencedCS[csRef] {
+			_ = cm.Client.Delete(ctx, &cs)
+		}
+	}
+
+	return results, nil
+}
+
+// annotateIfNotPresent sets MigratedFromCatalogSourceAnnotation on the ClusterCatalog
+// if it is not already present (idempotent).
+func (cm *CatalogMigrator) annotateIfNotPresent(ctx context.Context, cc *ocv1.ClusterCatalog, csRef string) error {
+	if _, ok := cc.Annotations[MigratedFromCatalogSourceAnnotation]; ok {
+		return nil // already set, leave it unchanged
+	}
+
+	patch := client.MergeFrom(cc.DeepCopy())
+	if cc.Annotations == nil {
+		cc.Annotations = make(map[string]string)
+	}
+	cc.Annotations[MigratedFromCatalogSourceAnnotation] = csRef
+	return cm.Client.Patch(ctx, cc, patch)
+}
+
+// waitForServing polls until the ClusterCatalog has Serving=True.
+func (cm *CatalogMigrator) waitForServing(ctx context.Context, ccName string) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		var cc ocv1.ClusterCatalog
+		if err := cm.Client.Get(ctx, client.ObjectKey{Name: ccName}, &cc); err != nil {
+			return false, err
+		}
+		for _, c := range cc.Status.Conditions {
+			if c.Type == "Serving" && c.Status == metav1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+// validatePriority checks that the CatalogSource priority fits in int32 range.
+// If it doesn't fit and AcknowledgePriorityOverflow is true, caps at MaxInt32/MinInt32.
+func validatePriority(priority int, acknowledge bool) (int32, error) {
+	if priority > math.MaxInt32 || priority < math.MinInt32 {
+		if !acknowledge {
+			return 0, fmt.Errorf("spec.priority %d is out of int32 range; pass --acknowledge-priority-overflow to cap and proceed", priority)
+		}
+		if priority > math.MaxInt32 {
+			return math.MaxInt32, nil
+		}
+		return math.MinInt32, nil
+	}
+	return int32(priority), nil //nolint:gosec // validated above
+}
+
+// convertPollInterval converts the CatalogSource registryPoll interval to integer minutes.
+// Returns 0 if no interval is set, or if the image ref is digest-based (poll not allowed).
+func convertPollInterval(cs operatorsv1alpha1.CatalogSource) int {
+	// Digest-based refs must not have a poll interval
+	if strings.Contains(cs.Spec.Image, "@sha256:") {
+		return 0
+	}
+
+	// Only convert explicitly set values (R8). When no UpdateStrategy is configured,
+	// leave pollIntervalMinutes unset so OLMv1 uses its own default rather than
+	// inheriting the OLMv0 default (15m) which was never explicitly chosen.
+	if cs.Spec.UpdateStrategy == nil || cs.Spec.UpdateStrategy.RegistryPoll == nil {
+		return 0
+	}
+
+	interval := cs.Spec.UpdateStrategy.Interval
+	if interval == nil || interval.Duration == 0 {
+		return 0
+	}
+
+	minutes := int(interval.Minutes())
+	if minutes < 1 {
+		minutes = 1
+	}
+	return minutes
+}


### PR DESCRIPTION
## Summary

Part 5/6 in the OLMv0→OLMv1 migration library stack (OPRUN-4717).

Implements the catalog migration library (R8) that converts OLMv0
`CatalogSource` resources to OLMv1 `ClusterCatalog` resources.

### Package: `migration/pkg/catalogmigration/`

**Naming / consolidation strategy (R8):**
- Same name + same image across namespaces → single `ClusterCatalog` using that name
- Same name + different image across namespaces → `<name>-<namespace>` per source
- Unique name → use `metadata.name` directly
- All `CatalogSource`s scanned before any `ClusterCatalog` is created

**Adopt-or-create:** existing `ClusterCatalog` with a matching `spec.source.image.ref`
is adopted with an idempotent `migrated-from-catalogsource` annotation.

**Field handling:**
- `spec.image` → `spec.source.image.ref`
- `spec.updateStrategy.registryPoll.interval` → `pollIntervalMinutes` (integer minutes);
  only when explicitly set; dropped for digest-based image refs
- `spec.priority` (int) → `spec.priority` (int32); out-of-range skipped by default;
  `--acknowledge-priority-overflow` caps at `MaxInt32`/`MinInt32`
- `spec.secrets`, `spec.grpcPodConfig` → noted in `CatalogMigrationResult.Notes` (no OLMv1 equivalent)
- `spec.configMap`, `spec.address` sources → reported as not migratable

**`--delete-catalogsource`** deletes the source only when the flag is set AND no
`Subscription` still references it.

### API

```go
CatalogMigrator.MigrateCatalogs(ctx, CatalogMigratorOptions) ([]CatalogMigrationResult, error)
```

`CatalogMigrationResult` carries `Status`, `Reason`, and `Notes` (informational notices).

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)