### PR TITLE
Add example CLIs exercising the migration library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/operator-framework/api v0.45.0
 	github.com/operator-framework/operator-controller v1.11.0
+	github.com/spf13/cobra v1.10.2
 	k8s.io/api v0.36.2
 	k8s.io/apiextensions-apiserver v0.36.2
 	k8s.io/apimachinery v0.36.2
@@ -37,12 +38,14 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -109,10 +110,12 @@ github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEy
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/migration/examples/cmd/migrate-catalogs-v0-to-v1/main.go
+++ b/migration/examples/cmd/migrate-catalogs-v0-to-v1/main.go
@@ -1,0 +1,184 @@
+// migrate-catalogs-v0-to-v1 migrates OLMv0 CatalogSources to OLMv1 ClusterCatalogs.
+// Run this before migrate-operators-v0-to-v1.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+
+	"github.com/operator-framework/library-olm/migration/pkg/catalogmigration"
+)
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(ocv1.AddToScheme(scheme))
+	utilruntime.Must(operatorsv1alpha1.AddToScheme(scheme))
+}
+
+var (
+	kubeconfig                  string
+	dryRun                      bool
+	deleteCatalogSource         bool
+	acknowledgePriorityOverflow bool
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "migrate-catalogs-v0-to-v1",
+	Short: "Migrate OLMv0 CatalogSources to OLMv1 ClusterCatalogs",
+	Long: `Scans all CatalogSources across all namespaces and creates
+corresponding OLMv1 ClusterCatalogs.
+
+Only grpc-type CatalogSources with a spec.image are migratable.
+configmap, internal, and address-only CatalogSources are reported as not migratable.
+
+Run this before migrate-operators-v0-to-v1.
+
+Examples:
+  migrate-catalogs-v0-to-v1
+  migrate-catalogs-v0-to-v1 --dry-run
+  migrate-catalogs-v0-to-v1 --delete-catalogsource`,
+	RunE: runMigrateCatalogs,
+}
+
+func init() {
+	rootCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file")
+	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print what would be created without modifying the cluster")
+	rootCmd.Flags().BoolVar(&deleteCatalogSource, "delete-catalogsource", false, "Delete source CatalogSource after migration (only when no Subscription references it)")
+	rootCmd.Flags().BoolVar(&acknowledgePriorityOverflow, "acknowledge-priority-overflow", false, "Cap out-of-range priority at MaxInt32/MinInt32 and proceed")
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newClient() (client.Client, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfig != "" {
+		loadingRules.ExplicitPath = kubeconfig
+	}
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		&clientcmd.ConfigOverrides{},
+	)
+
+	restConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get REST config: %w", err)
+	}
+
+	c, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+	return c, nil
+}
+
+func runMigrateCatalogs(cmd *cobra.Command, _ []string) error {
+	c, err := newClient()
+	if err != nil {
+		return err
+	}
+
+	cm := catalogmigration.NewCatalogMigrator(c)
+	opts := catalogmigration.CatalogMigratorOptions{
+		DryRun:                      dryRun,
+		DeleteCatalogSource:         deleteCatalogSource,
+		AcknowledgePriorityOverflow: acknowledgePriorityOverflow,
+	}
+
+	if dryRun {
+		fmt.Printf("\n🔍 Dry run — no cluster changes will be made.\n\n")
+	} else {
+		fmt.Printf("\n🔄 Migrating CatalogSources to ClusterCatalogs...\n\n")
+	}
+
+	results, err := cm.MigrateCatalogs(cmd.Context(), opts)
+	if err != nil {
+		return fmt.Errorf("catalog migration failed: %w", err)
+	}
+
+	// Print results grouped by status
+	var created, adopted, skipped, errored, dryResults []catalogmigration.CatalogMigrationResult
+	for _, r := range results {
+		switch r.Status {
+		case "created":
+			created = append(created, r)
+		case "adopted":
+			adopted = append(adopted, r)
+		case "skipped":
+			skipped = append(skipped, r)
+		case "error":
+			errored = append(errored, r)
+		case "dry-run":
+			dryResults = append(dryResults, r)
+		}
+	}
+
+	if len(dryResults) > 0 {
+		fmt.Printf("Would migrate:\n")
+		for _, r := range dryResults {
+			fmt.Printf("  %-40s → %s\n    %s\n",
+				r.CatalogSourceNamespace+"/"+r.CatalogSourceName,
+				r.ClusterCatalogName, r.Reason)
+		}
+	}
+
+	if len(created) > 0 {
+		fmt.Printf("\n✅ Created (%d):\n", len(created))
+		for _, r := range created {
+			fmt.Printf("  ✓ %s/%s → ClusterCatalog/%s\n",
+				r.CatalogSourceNamespace, r.CatalogSourceName, r.ClusterCatalogName)
+		}
+	}
+
+	if len(adopted) > 0 {
+		fmt.Printf("\n✅ Adopted existing (%d):\n", len(adopted))
+		for _, r := range adopted {
+			fmt.Printf("  ✓ %s/%s → ClusterCatalog/%s\n",
+				r.CatalogSourceNamespace, r.CatalogSourceName, r.ClusterCatalogName)
+		}
+	}
+
+	if len(skipped) > 0 {
+		fmt.Printf("\n⏭  Skipped (%d):\n", len(skipped))
+		for _, r := range skipped {
+			fmt.Printf("  - %s/%s: %s\n",
+				r.CatalogSourceNamespace, r.CatalogSourceName, r.Reason)
+		}
+	}
+
+	if len(errored) > 0 {
+		fmt.Printf("\n❌ Errors (%d):\n", len(errored))
+		for _, r := range errored {
+			fmt.Printf("  ✗ %s/%s: %s\n",
+				r.CatalogSourceNamespace, r.CatalogSourceName, r.Reason)
+		}
+		return fmt.Errorf("%d catalog source(s) failed to migrate", len(errored))
+	}
+
+	total := len(created) + len(adopted)
+	if total > 0 {
+		fmt.Printf("\n✅ Done: %d ClusterCatalog(s) ready\n\n", total)
+	} else if dryRun {
+		fmt.Printf("\nDry run complete.\n\n")
+	} else {
+		fmt.Printf("\nNo migratable CatalogSources found.\n\n")
+	}
+
+	return nil
+}

--- a/migration/examples/cmd/migrate-operators-v0-to-v1/check.go
+++ b/migration/examples/cmd/migrate-operators-v0-to-v1/check.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/library-olm/migration/pkg/migration"
+)
+
+var (
+	checkSubscriptionNamespace string
+	checkAll                   bool
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check [operator-name]",
+	Short: "Check readiness and compatibility without performing migration",
+	Long: `Runs all pre-migration checks (readiness and compatibility) and reports
+any issues that would prevent migration. Does not modify any cluster resources.
+
+Target is a Subscription name (with -n namespace), or --all to scan the cluster.
+
+Examples:
+  migrate-operators-v0-to-v1 check my-operator -n operators
+  migrate-operators-v0-to-v1 check --all`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runCheck,
+}
+
+func init() {
+	checkCmd.Flags().StringVarP(&checkSubscriptionNamespace, "namespace", "n", "", "Subscription namespace (required without --all)")
+	checkCmd.Flags().BoolVar(&checkAll, "all", false, "Check all Subscriptions on the cluster")
+}
+
+func runCheck(cmd *cobra.Command, args []string) error { //nolint:nestif
+	if checkAll && len(args) > 0 {
+		return fmt.Errorf("cannot specify both an operator name and --all")
+	}
+	if !checkAll && len(args) == 0 {
+		return fmt.Errorf("specify an operator name or --all")
+	}
+
+	c, restCfg, err := newClient()
+	if err != nil {
+		return err
+	}
+
+	m := migration.NewMigrator(c, restCfg)
+	m.Progress = progressFunc
+	ctx := cmd.Context()
+
+	if checkAll {
+		fmt.Printf("\n%s%s🔎 Scanning all Subscriptions...%s\n", colorBold, colorCyan, colorReset)
+		startProgress()
+		results, err := m.ScanAllSubscriptions(ctx)
+		clearProgress()
+		if err != nil {
+			return fmt.Errorf("scan failed: %w", err)
+		}
+		migration.PrintScanSummary(results, func(format string, a ...interface{}) {
+			fmt.Printf(format, a...)
+		})
+		return nil
+	}
+
+	operatorName := args[0]
+	if checkSubscriptionNamespace == "" {
+		return fmt.Errorf("-n/--namespace is required")
+	}
+
+	fmt.Printf("\n%s%s🔍 Pre-migration checks for %s/%s%s\n", colorBold, colorCyan, checkSubscriptionNamespace, operatorName, colorReset)
+
+	opts := migration.Options{
+		SubscriptionName:      operatorName,
+		SubscriptionNamespace: checkSubscriptionNamespace,
+	}
+	opts.ApplyDefaults()
+
+	sectionHeader("Readiness Checks")
+	readiness, readinessErr := m.CheckReadiness(ctx, opts)
+	if readinessErr != nil {
+		fail(fmt.Sprintf("Could not run readiness checks: %v", readinessErr))
+	} else {
+		printCheckResults(readiness.Checks)
+	}
+
+	sectionHeader("Compatibility Checks")
+	_, csv, _, profileErr := m.GetCSVAndInstallPlan(ctx, opts)
+	if profileErr != nil { //nolint:nestif
+		fail(fmt.Sprintf("Could not profile operator: %v", profileErr))
+	} else {
+		propsJSON := csv.Annotations["operatorframework.io/properties"]
+		compat, compatErr := m.CheckCompatibility(ctx, opts, csv, propsJSON)
+		if compatErr != nil {
+			fail(fmt.Sprintf("Could not run compatibility checks: %v", compatErr))
+		} else {
+			printCheckResults(compat.Checks)
+		}
+
+		sectionHeader("ClusterCatalog Availability")
+		bundleInfo, _ := m.GetBundleInfo(ctx, opts, csv, nil)
+		if bundleInfo != nil {
+			catalogName, catalogErr := m.ResolveClusterCatalog(ctx, bundleInfo, restCfg)
+			if catalogErr != nil {
+				var notFound *migration.PackageNotFoundError
+				if errors.As(catalogErr, &notFound) {
+					warn(fmt.Sprintf("No ClusterCatalog found for package %q — run migrate-catalogs-v0-to-v1 first", bundleInfo.PackageName))
+				} else {
+					warn(fmt.Sprintf("Catalog resolution error: %v", catalogErr))
+				}
+			} else {
+				success(fmt.Sprintf("ClusterCatalog available: %s", catalogName))
+			}
+		}
+	}
+
+	fmt.Println()
+	return nil
+}

--- a/migration/examples/cmd/migrate-operators-v0-to-v1/cleanup.go
+++ b/migration/examples/cmd/migrate-operators-v0-to-v1/cleanup.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+
+	"github.com/operator-framework/library-olm/migration/pkg/migration"
+)
+
+var cleanupAll bool
+
+var cleanupCmd = &cobra.Command{
+	Use:   "cleanup [ce-name]",
+	Short: "Finish a partial migration (Conflict state)",
+	Long: `Resolves a Conflict state by deleting the Subscription and OLMv0 artifacts,
+leaving the ClusterExtension intact.
+
+Use this when both a Subscription and an annotated ClusterExtension exist,
+indicating a failed cleanup from a previous migration attempt.
+
+Target is a ClusterExtension name, or --all to cleanup all conflicts.
+
+Examples:
+  migrate-operators-v0-to-v1 cleanup my-operator
+  migrate-operators-v0-to-v1 cleanup --all`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runCleanup,
+}
+
+func init() {
+	cleanupCmd.Flags().BoolVar(&cleanupAll, "all", false, "Cleanup all Conflict-state ClusterExtensions")
+}
+
+func runCleanup(cmd *cobra.Command, args []string) error { //nolint:nestif
+	if cleanupAll && len(args) > 0 {
+		return fmt.Errorf("cannot specify both a CE name and --all")
+	}
+	if !cleanupAll && len(args) == 0 {
+		return fmt.Errorf("specify a ClusterExtension name or --all")
+	}
+
+	c, restCfg, err := newClient()
+	if err != nil {
+		return err
+	}
+
+	m := migration.NewMigrator(c, restCfg)
+	m.Progress = progressFunc
+	ctx := cmd.Context()
+
+	if cleanupAll { //nolint:nestif
+		// Find all CEs that are in Conflict state
+		results, err := m.ScanAllSubscriptions(ctx)
+		if err != nil {
+			return fmt.Errorf("scan failed: %w", err)
+		}
+
+		// Also scan CEs for those with the annotation
+		var ceList ocv1.ClusterExtensionList
+		if err := c.List(ctx, &ceList); err != nil {
+			return fmt.Errorf("failed to list ClusterExtensions: %w", err)
+		}
+
+		var conflictCEs []string
+		for _, r := range results {
+			if r.Status == migration.OperatorStatusConflict {
+				// Find the CE name from the annotation
+				subRef := fmt.Sprintf("%s/%s", r.SubscriptionNamespace, r.SubscriptionName)
+				for _, ce := range ceList.Items {
+					if ce.Annotations[migration.MigratedFromSubscriptionAnnotation] == subRef {
+						conflictCEs = append(conflictCEs, ce.Name)
+						break
+					}
+				}
+			}
+		}
+
+		if len(conflictCEs) == 0 {
+			info("No Conflict-state ClusterExtensions found.")
+			return nil
+		}
+
+		fmt.Printf("\nCleaning up %d Conflict-state ClusterExtension(s)...\n", len(conflictCEs))
+		var firstErr error
+		for _, ceName := range conflictCEs {
+			if err := m.CleanupConflict(ctx, ceName); err != nil {
+				fail(fmt.Sprintf("%s: %v", ceName, err))
+				if firstErr == nil {
+					firstErr = err
+				}
+			} else {
+				success(fmt.Sprintf("%s conflict resolved", ceName))
+			}
+		}
+		return firstErr
+	}
+
+	ceName := args[0]
+	fmt.Printf("\n%s%s🧹 Cleaning up Conflict for %s...%s\n", colorBold, colorCyan, ceName, colorReset)
+
+	if err := m.CleanupConflict(ctx, ceName); err != nil {
+		fail(fmt.Sprintf("Cleanup failed: %v", err))
+		return err
+	}
+
+	success(fmt.Sprintf("Conflict resolved for %s; OLMv0 artifacts removed, ClusterExtension intact", ceName))
+	fmt.Println()
+	return nil
+}

--- a/migration/examples/cmd/migrate-operators-v0-to-v1/convert.go
+++ b/migration/examples/cmd/migrate-operators-v0-to-v1/convert.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/library-olm/migration/pkg/migration"
+)
+
+var (
+	convertNamespace     string
+	convertAll           bool
+	convertDryRun        bool
+	convertContinueOnErr bool
+	convertBackupDir     string
+	convertDeleteOG      bool
+	convertCEName        string
+	convertInstallNs     string
+
+	// Acknowledgment flags
+	convertAckWatchScope bool
+	convertAckOpCond     bool
+	convertAckOLMv0API   bool
+	convertAckScopedSA   bool
+	convertAckNotSteady  bool
+)
+
+var convertCmd = &cobra.Command{
+	Use:   "convert [operator-name]",
+	Short: "Migrate an OLMv0 operator to OLMv1",
+	Long: `Migrates an OLMv0 Subscription/CSV to OLMv1 ClusterExtension/ClusterObjectSet.
+
+Use --dry-run to preview without making changes.
+Use --all to migrate all eligible operators.
+
+Target is a Subscription name (with -n namespace), or --all.
+
+Examples:
+  migrate-operators-v0-to-v1 convert my-operator -n operators
+  migrate-operators-v0-to-v1 convert my-operator -n operators --dry-run
+  migrate-operators-v0-to-v1 convert --all
+  migrate-operators-v0-to-v1 convert --all --continue-on-error`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runConvert,
+}
+
+func init() {
+	convertCmd.Flags().StringVarP(&convertNamespace, "namespace", "n", "", "Subscription namespace (required without --all)")
+	convertCmd.Flags().BoolVar(&convertAll, "all", false, "Migrate all eligible operators")
+	convertCmd.Flags().BoolVar(&convertDryRun, "dry-run", false, "Preview what would be migrated without making changes")
+	convertCmd.Flags().BoolVar(&convertContinueOnErr, "continue-on-error", false, "Continue migrating other operators when one fails (--all only)")
+	convertCmd.Flags().StringVar(&convertBackupDir, "backup", "", "Directory to write OLM resource backups before deletion")
+	convertCmd.Flags().BoolVar(&convertDeleteOG, "delete-operatorgroup", false, "Delete the OperatorGroup when no other Subscriptions remain")
+	convertCmd.Flags().StringVar(&convertCEName, "ce-name", "", "ClusterExtension name (default: Subscription name)")
+	convertCmd.Flags().StringVar(&convertInstallNs, "install-namespace", "", "Install namespace (default: Subscription namespace)")
+	convertCmd.Flags().BoolVar(&convertAckWatchScope, "acknowledge-watch-scope-change", false, "Acknowledge that the operator will run AllNamespaces (was scoped)")
+	convertCmd.Flags().BoolVar(&convertAckOpCond, "acknowledge-operator-condition", false, "Acknowledge active OperatorCondition usage")
+	convertCmd.Flags().BoolVar(&convertAckOLMv0API, "acknowledge-olmv0-api-access", false, "Acknowledge OLMv0 API RBAC without OLMv1 equivalent")
+	convertCmd.Flags().BoolVar(&convertAckScopedSA, "acknowledge-scoped-serviceaccount", false, "Acknowledge scoped OperatorGroup ServiceAccount (will use cluster-admin)")
+	convertCmd.Flags().BoolVar(&convertAckNotSteady, "acknowledge-not-steady-state", false, "Acknowledge that the operator is not at steady state")
+}
+
+func runConvert(cmd *cobra.Command, args []string) error { //nolint:nestif
+	if convertAll && len(args) > 0 {
+		return fmt.Errorf("cannot specify both an operator name and --all")
+	}
+	if !convertAll && len(args) == 0 {
+		return fmt.Errorf("specify an operator name or --all")
+	}
+
+	c, restCfg, err := newClient()
+	if err != nil {
+		return err
+	}
+
+	m := migration.NewMigrator(c, restCfg)
+	m.Progress = progressFunc
+	ctx := cmd.Context()
+
+	if convertAll { //nolint:nestif
+		fmt.Printf("\n%s%s🔎 Scanning all Subscriptions for migration...%s\n", colorBold, colorCyan, colorReset)
+		startProgress()
+		results, err := m.ScanAllSubscriptions(ctx)
+		clearProgress()
+		if err != nil {
+			return fmt.Errorf("scan failed: %w", err)
+		}
+
+		migration.PrintScanSummary(results, func(format string, a ...interface{}) {
+			fmt.Printf(format, a...)
+		})
+
+		eligible := migration.EligibleFromScan(results)
+		if len(eligible) == 0 {
+			info("No eligible operators to migrate.")
+			return nil
+		}
+
+		fmt.Printf("\n%s%sMigrating %d eligible operator(s)...%s\n", colorBold, colorCyan, len(eligible), colorReset)
+
+		var firstErr error
+		for _, r := range eligible {
+			info(fmt.Sprintf("Migrating %s/%s...", r.SubscriptionNamespace, r.SubscriptionName))
+			opts := migration.Options{
+				SubscriptionName:                r.SubscriptionName,
+				SubscriptionNamespace:           r.SubscriptionNamespace,
+				BackupDirectory:                 convertBackupDir,
+				DeleteOperatorGroup:             convertDeleteOG,
+				AcknowledgeWatchScopeChange:     convertAckWatchScope,
+				AcknowledgeOperatorCondition:    convertAckOpCond,
+				AcknowledgeOLMv0APIAccess:       convertAckOLMv0API,
+				AcknowledgeScopedServiceAccount: convertAckScopedSA,
+				AcknowledgeNotSteadyState:       convertAckNotSteady,
+			}
+			opts.ApplyDefaults()
+
+			if err := m.Migrate(ctx, opts); err != nil {
+				fail(fmt.Sprintf("%s/%s: %v", r.SubscriptionNamespace, r.SubscriptionName, err))
+				if !convertContinueOnErr {
+					return err
+				}
+				if firstErr == nil {
+					firstErr = err
+				}
+			} else {
+				success(fmt.Sprintf("%s/%s migrated", r.SubscriptionNamespace, r.SubscriptionName))
+			}
+		}
+		return firstErr
+	}
+
+	// Single operator
+	operatorName := args[0]
+	if convertNamespace == "" {
+		return fmt.Errorf("-n/--namespace is required")
+	}
+
+	opts := migration.Options{
+		SubscriptionName:                operatorName,
+		SubscriptionNamespace:           convertNamespace,
+		ClusterExtensionName:            convertCEName,
+		InstallNamespace:                convertInstallNs,
+		BackupDirectory:                 convertBackupDir,
+		DeleteOperatorGroup:             convertDeleteOG,
+		AcknowledgeWatchScopeChange:     convertAckWatchScope,
+		AcknowledgeOperatorCondition:    convertAckOpCond,
+		AcknowledgeOLMv0APIAccess:       convertAckOLMv0API,
+		AcknowledgeScopedServiceAccount: convertAckScopedSA,
+		AcknowledgeNotSteadyState:       convertAckNotSteady,
+	}
+	opts.ApplyDefaults()
+
+	if convertDryRun {
+		return runConvertDryRun(cmd, m, opts)
+	}
+
+	fmt.Printf("\n%s%s🔄 Migrating %s/%s to OLMv1...%s\n", colorBold, colorCyan, convertNamespace, operatorName, colorReset)
+
+	stepHeader(1, "Profiling operator")
+	_, csv, ip, err := m.GetCSVAndInstallPlan(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("failed to profile operator: %w", err)
+	}
+	bundleInfo, err := m.GetBundleInfo(ctx, opts, csv, ip)
+	if err != nil {
+		return fmt.Errorf("failed to get bundle info: %w", err)
+	}
+	detail("Package:", bundleInfo.PackageName)
+	detail("Version:", bundleInfo.Version)
+	detail("Channel:", valueOrDefault(bundleInfo.Channel, "(default)"))
+	success("Operator profiled")
+
+	stepHeader(2, "Checking readiness and compatibility")
+	sectionHeader("Readiness")
+	readiness, err := m.CheckReadiness(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("readiness check failed: %w", err)
+	}
+	printCheckResults(readiness.Checks)
+
+	sectionHeader("Compatibility")
+	propsJSON := csv.Annotations["operatorframework.io/properties"]
+	compat, err := m.CheckCompatibility(ctx, opts, csv, propsJSON)
+	if err != nil {
+		return fmt.Errorf("compatibility check failed: %w", err)
+	}
+	printCheckResults(compat.Checks)
+
+	allFailed := append(readiness.FailedChecks(), compat.FailedChecks()...)
+	if len(allFailed) > 0 {
+		return fmt.Errorf("operator is not eligible for migration (%d checks failed)", len(allFailed))
+	}
+
+	stepHeader(3, "Determining target ClusterCatalog")
+	startProgress()
+	catalogName, err := m.ResolveClusterCatalog(ctx, bundleInfo, restCfg)
+	clearProgress()
+	if err != nil {
+		var notFound *migration.PackageNotFoundError
+		if errors.As(err, &notFound) {
+			fail(fmt.Sprintf("No ClusterCatalog found for package %q — run migrate-catalogs-v0-to-v1 first", bundleInfo.PackageName))
+		}
+		return fmt.Errorf("failed to resolve ClusterCatalog: %w", err)
+	}
+	bundleInfo.ResolvedCatalogName = catalogName
+	success(fmt.Sprintf("Selected ClusterCatalog: %s", catalogName))
+
+	stepHeader(4, "Collecting operator resources")
+	objects, err := m.CollectResources(ctx, opts, csv, ip, bundleInfo.PackageName)
+	if err != nil {
+		return fmt.Errorf("failed to collect resources: %w", err)
+	}
+	bundleInfo.CollectedObjects = objects
+	kindCounts := make(map[string]int)
+	for _, obj := range objects {
+		kindCounts[obj.GetKind()]++
+	}
+	success(fmt.Sprintf("Found %d resources across %d kinds", len(objects), len(kindCounts)))
+
+	stepHeader(5, "Backing up resources")
+	backup, err := m.BackupResources(ctx, opts, csv, ip)
+	if err != nil {
+		return fmt.Errorf("failed to backup resources: %w", err)
+	}
+	// Populate CE backup annotations (R2.5) — before PrepareForMigration deletes the Sub.
+	if backup.Subscription != nil {
+		if j, jErr := json.Marshal(backup.Subscription.Spec); jErr == nil {
+			bundleInfo.SubscriptionBackupJSON = string(j)
+		}
+	}
+	if backup.OperatorGroup != nil {
+		if j, jErr := json.Marshal(backup.OperatorGroup.Spec); jErr == nil {
+			bundleInfo.OperatorGroupBackupJSON = string(j)
+		}
+	}
+	// Disk backup (non-fatal per R2.6).
+	if convertBackupDir != "" {
+		if err := backup.SaveToDisk(convertBackupDir); err != nil {
+			warn(fmt.Sprintf("Backup to disk failed (CE annotation backup is authoritative): %v", err))
+		} else {
+			success(fmt.Sprintf("Backup written to %s", convertBackupDir))
+		}
+	}
+	success("Resources backed up in memory (CE annotation backup authoritative)")
+
+	stepHeader(6, "Preparing operator for migration")
+	info("Deleting Subscription and CSV (orphan cascade — workloads keep running)...")
+	if err := m.PrepareForMigration(ctx, opts, csv); err != nil {
+		return fmt.Errorf("preparation failed: %w", err)
+	}
+	success("OLMv0 management removed")
+
+	stepHeader(7, "Creating ClusterObjectSet")
+	info(fmt.Sprintf("Applying COS %s-1 with %d objects...", opts.ClusterExtensionName, len(bundleInfo.CollectedObjects)))
+	startProgress()
+	if err := m.CreateClusterObjectSet(ctx, opts, bundleInfo); err != nil {
+		clearProgress()
+		return fmt.Errorf("COS creation failed: %w", err)
+	}
+	clearProgress()
+	success(fmt.Sprintf("ClusterObjectSet %s-1 reached Succeeded=True", opts.ClusterExtensionName))
+
+	stepHeader(8, "Creating ClusterExtension")
+	startProgress()
+	if err := m.CreateClusterExtension(ctx, opts, bundleInfo); err != nil {
+		clearProgress()
+		return fmt.Errorf("failed to create ClusterExtension: %w", err)
+	}
+	clearProgress()
+	success(fmt.Sprintf("ClusterExtension %s is Installed", opts.ClusterExtensionName))
+
+	stepHeader(9, "Cleaning up OLMv0 resources")
+	cleanupResult := m.CleanupOLMv0Resources(ctx, opts, bundleInfo.PackageName, csv.Name)
+	for _, action := range cleanupResult.Actions {
+		switch {
+		case action.Skipped:
+			info(fmt.Sprintf("⏭  %s", action.Description))
+		case action.Error != nil:
+			warn(fmt.Sprintf("%s: %v", action.Description, action.Error))
+		case action.Succeeded:
+			success(action.Description)
+		}
+	}
+
+	banner(fmt.Sprintf("Migration complete! %s is now managed by OLMv1", bundleInfo.PackageName))
+	fmt.Println()
+	return nil
+}
+
+func runConvertDryRun(cmd *cobra.Command, m *migration.Migrator, opts migration.Options) error {
+	ctx := cmd.Context()
+	fmt.Printf("\n%s%s🔍 Dry run: %s/%s%s\n", colorBold, colorCyan, opts.SubscriptionNamespace, opts.SubscriptionName, colorReset)
+
+	info, err := m.GatherMigrationInfo(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("failed to gather migration info: %w", err)
+	}
+
+	success(fmt.Sprintf("Package: %s  Version: %s  Channel: %s", info.PackageName, info.Version, valueOrDefault(info.Channel, "(default)")))
+	fmt.Printf("\n  Resources that would be placed into ClusterObjectSet %s-1:\n", opts.ClusterExtensionName)
+
+	kindCounts := make(map[string]int)
+	for _, obj := range info.CollectedObjects {
+		kindCounts[obj.GetKind()]++
+	}
+	for kind, count := range kindCounts {
+		detail(fmt.Sprintf("%s:", kind), fmt.Sprintf("%d object(s)", count))
+	}
+
+	fmt.Printf("\n  ClusterExtension that would be created:\n")
+	detail("Name:", opts.ClusterExtensionName)
+	detail("Namespace:", opts.InstallNamespace)
+	detail("PackageName:", info.PackageName)
+	if info.ManualApproval {
+		detail("Version:", fmt.Sprintf("%s (pinned — manual approval)", info.Version))
+	} else {
+		detail("Version:", "(unset — automatic channel-based upgrades)")
+	}
+	detail("Channel:", valueOrDefault(info.Channel, "(none set)"))
+	detail("CollisionProtection:", "IfNoController")
+
+	fmt.Println()
+	info2("No cluster resources were modified (dry run).")
+	return nil
+}
+
+func info2(msg string) {
+	fmt.Printf("  %s\n", msg)
+}
+
+func valueOrDefault(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
+}

--- a/migration/examples/cmd/migrate-operators-v0-to-v1/main.go
+++ b/migration/examples/cmd/migrate-operators-v0-to-v1/main.go
@@ -1,0 +1,90 @@
+// migrate-operators-v0-to-v1 is a CLI tool for migrating operators managed by
+// OLMv0 (Subscription/CSV) to OLMv1 (ClusterExtension/ClusterObjectSet).
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+)
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(ocv1.AddToScheme(scheme))
+	utilruntime.Must(appsv1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(operatorsv1.AddToScheme(scheme))
+	utilruntime.Must(operatorsv1alpha1.AddToScheme(scheme))
+}
+
+var kubeconfig string
+
+var rootCmd = &cobra.Command{
+	Use:   "migrate-operators-v0-to-v1",
+	Short: "Migrate OLMv0-managed operators to OLMv1",
+	Long: `migrate-operators-v0-to-v1 migrates operators from OLMv0 (Subscription/CSV)
+to OLMv1 (ClusterExtension/ClusterObjectSet).
+
+Run migrate-catalogs-v0-to-v1 first to create ClusterCatalogs from CatalogSources.
+
+Subcommands:
+  check   — report readiness and compatibility (no changes)
+  convert — perform the migration
+  rollback — restore an operator to OLMv0 management
+  cleanup — finish a partial migration (Conflict state)`,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (default: KUBECONFIG env or ~/.kube/config)")
+
+	rootCmd.AddCommand(checkCmd)
+	rootCmd.AddCommand(convertCmd)
+	rootCmd.AddCommand(rollbackCmd)
+	rootCmd.AddCommand(cleanupCmd)
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newClient() (client.Client, *rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfig != "" {
+		loadingRules.ExplicitPath = kubeconfig
+	}
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		&clientcmd.ConfigOverrides{},
+	)
+
+	restConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get REST config: %w", err)
+	}
+
+	c, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create client: %w", err)
+	}
+	return c, restConfig, nil
+}

--- a/migration/examples/cmd/migrate-operators-v0-to-v1/output.go
+++ b/migration/examples/cmd/migrate-operators-v0-to-v1/output.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/operator-framework/library-olm/migration/pkg/migration"
+)
+
+const (
+	colorReset  = "\033[0m"
+	colorRed    = "\033[31m"
+	colorGreen  = "\033[32m"
+	colorYellow = "\033[33m"
+	colorCyan   = "\033[36m"
+	colorBold   = "\033[1m"
+	colorDim    = "\033[2m"
+)
+
+var (
+	progressMu      sync.Mutex
+	progressRunning bool
+	progressMsg     string
+)
+
+func progressFunc(msg string) {
+	progressMu.Lock()
+	defer progressMu.Unlock()
+	progressMsg = msg
+	if progressRunning {
+		fmt.Printf("\r  %s%s...%s", colorDim, msg, colorReset)
+	}
+}
+
+func startProgress() {
+	progressMu.Lock()
+	progressRunning = true
+	progressMu.Unlock()
+}
+
+func clearProgress() {
+	progressMu.Lock()
+	progressRunning = false
+	if progressMsg != "" {
+		fmt.Printf("\r%80s\r", "") // clear the line
+	}
+	progressMsg = ""
+	progressMu.Unlock()
+}
+
+func stepHeader(n int, title string) {
+	fmt.Printf("\n%s%sStep %d: %s%s\n", colorBold, colorCyan, n, title, colorReset)
+}
+
+func sectionHeader(title string) {
+	fmt.Printf("\n  %s%s%s\n", colorBold, title, colorReset)
+}
+
+func banner(msg string) {
+	fmt.Printf("\n%s%s✅ %s%s\n", colorBold, colorGreen, msg, colorReset)
+}
+
+func success(msg string) {
+	fmt.Printf("  %s✓%s %s\n", colorGreen, colorReset, msg)
+}
+
+func fail(msg string) {
+	fmt.Printf("  %s✗%s %s\n", colorRed, colorReset, msg)
+}
+
+func warn(msg string) {
+	fmt.Printf("  %s⚠%s  %s\n", colorYellow, colorReset, msg)
+}
+
+func info(msg string) {
+	fmt.Printf("  %s\n", msg)
+}
+
+func detail(key, value string) {
+	fmt.Printf("    %s%-22s%s %s\n", colorDim, key, colorReset, value)
+}
+
+func printCheckResults(checks []migration.CheckResult) {
+	for _, c := range checks {
+		if c.Passed {
+			success(fmt.Sprintf("%-35s %s%s%s", c.Name, colorDim, c.Message, colorReset))
+		} else {
+			fail(fmt.Sprintf("%-35s %s", c.Name, c.Message))
+		}
+	}
+}

--- a/migration/examples/cmd/migrate-operators-v0-to-v1/rollback.go
+++ b/migration/examples/cmd/migrate-operators-v0-to-v1/rollback.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+
+	"github.com/operator-framework/library-olm/migration/pkg/migration"
+)
+
+var (
+	rollbackAll                  bool
+	rollbackAcknowledgeInstalled bool
+)
+
+var rollbackCmd = &cobra.Command{
+	Use:   "rollback [ce-name]",
+	Short: "Restore an operator to OLMv0 management",
+	Long: `Deletes the ClusterExtension and ClusterObjectSet (orphan cascade),
+then restores the Subscription from the backup annotation.
+
+Requires --acknowledge-installed when the ClusterExtension is Installed=True.
+
+Target is a ClusterExtension name, or --all to rollback all migrated CEs.
+
+Examples:
+  migrate-operators-v0-to-v1 rollback my-operator --acknowledge-installed
+  migrate-operators-v0-to-v1 rollback --all --acknowledge-installed`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runRollback,
+}
+
+func init() {
+	rollbackCmd.Flags().BoolVar(&rollbackAll, "all", false, "Rollback all migrated ClusterExtensions")
+	rollbackCmd.Flags().BoolVar(&rollbackAcknowledgeInstalled, "acknowledge-installed", false, "Confirm rollback even when CE is Installed=True")
+}
+
+func runRollback(cmd *cobra.Command, args []string) error { //nolint:nestif
+	if rollbackAll && len(args) > 0 {
+		return fmt.Errorf("cannot specify both a CE name and --all")
+	}
+	if !rollbackAll && len(args) == 0 {
+		return fmt.Errorf("specify a ClusterExtension name or --all")
+	}
+
+	c, restCfg, err := newClient()
+	if err != nil {
+		return err
+	}
+
+	m := migration.NewMigrator(c, restCfg)
+	m.Progress = progressFunc
+	ctx := cmd.Context()
+
+	if rollbackAll { //nolint:nestif
+		var ceList ocv1.ClusterExtensionList
+		if err := c.List(ctx, &ceList); err != nil {
+			return fmt.Errorf("failed to list ClusterExtensions: %w", err)
+		}
+
+		var targets []string
+		for _, ce := range ceList.Items {
+			if _, ok := ce.Annotations[migration.MigratedFromSubscriptionAnnotation]; ok {
+				targets = append(targets, ce.Name)
+			}
+		}
+
+		if len(targets) == 0 {
+			info("No migrated ClusterExtensions found.")
+			return nil
+		}
+
+		fmt.Printf("\nRolling back %d migrated ClusterExtension(s)...\n", len(targets))
+		var firstErr error
+		for _, name := range targets {
+			if err := m.RollbackClusterExtension(ctx, name, rollbackAcknowledgeInstalled); err != nil {
+				fail(fmt.Sprintf("%s: %v", name, err))
+				if firstErr == nil {
+					firstErr = err
+				}
+			} else {
+				success(fmt.Sprintf("%s rolled back", name))
+			}
+		}
+		return firstErr
+	}
+
+	ceName := args[0]
+	fmt.Printf("\n%s%s🔄 Rolling back ClusterExtension %s...%s\n", colorBold, colorCyan, ceName, colorReset)
+
+	if err := m.RollbackClusterExtension(ctx, ceName, rollbackAcknowledgeInstalled); err != nil {
+		fail(fmt.Sprintf("Rollback failed: %v", err))
+		return err
+	}
+
+	success(fmt.Sprintf("ClusterExtension %s rolled back; Subscription restored", ceName))
+	fmt.Println()
+	return nil
+}


### PR DESCRIPTION
## Summary

Part 6/6 in the OLMv0→OLMv1 migration library stack (OPRUN-4717).

Adds two example CLI binaries under `migration/examples/cmd/` that demonstrate
the migration library API. Per the design, these are **prototype consumers** — not
production delivery artifacts. Production CLIs (`oc` plugin, Console) will import
`migration/pkg/*` directly and build their own CLI surface.

### `migrate-operators-v0-to-v1`

Verb-plus-target style (kubectl/`oc`-style), each verb taking an operator name or `--all`:

| Command | Purpose |
|---|---|
| `check <op> \| --all -n <ns>` | Readiness + compatibility + catalog check; no mutations |
| `convert <op> \| --all -n <ns>` | Full migration; `--dry-run`, `--backup <dir>`, `--delete-operatorgroup`, `--continue-on-error`, `--acknowledge-*` flags |
| `rollback <ce> \| --all` | Restore operator to OLMv0 management; `--acknowledge-installed` |
| `cleanup <ce> \| --all` | Finish a partial migration (Conflict state) |

### `migrate-catalogs-v0-to-v1`

Single command with `--dry-run`, `--delete-catalogsource`, `--acknowledge-priority-overflow`.

### Build

```
make build
```

Produces `bin/migrate-operators-v0-to-v1` and `bin/migrate-catalogs-v0-to-v1`.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)